### PR TITLE
Updated Helpers.cs tryReadFile method so that it handles exceptions that may happen, without crashing the program.

### DIFF
--- a/dotnet/DWXConnect/api/Helpers.cs
+++ b/dotnet/DWXConnect/api/Helpers.cs
@@ -65,27 +65,47 @@ namespace DWXConnect
         }
 		
 		
-		/*Formats a double value to string. 
-		
-		Args:
-			value (double): numeric value to format.
-		
-		*/
-		public static string format(double value)
+	/*Formats a double value to string. 
+	
+	Args:
+		value (double): numeric value to format.
+	
+	*/
+	public static string format(double value)
         {
             return value.ToString("G", CultureInfo.CreateSpecificCulture("en-US"));
         }
 
-        public static string tryReadFile(string path)
-        {
-            try
-            {
-                return File.ReadAllText(path);
-            }
-            catch
-            {
-                return "";
-            }
-        }
+	/*Tries to read a file and handles various exceptions which then return an empty string and writes the exception to the console.
+	
+ 	*/
+	public static string tryReadFile(string path)
+    	{
+	        try
+	        {
+	            return File.ReadAllText(path);
+	        }
+	        catch (DirectoryNotFoundException)
+	        {
+	            Console.WriteLine("api.Helpers.tryReadFile | DirectoryNotFoundException. Returning empty string.");
+	            return "";
+	        }
+	        catch (FileNotFoundException)
+	        {
+	            Console.WriteLine($"api.Helpers.tryReadFile | FileNotFoundException. Creating empty file at path ({path}) & returning empty string.");
+	            CreateEmptyFile(path);
+	            return "";
+	        }
+	        catch (IOException)
+	        {
+	            Console.WriteLine("api.Helpers.tryReadFile | IOException. Race condition. Most likely this process and the MetaTrader EA both trying to access/use the file simultaneously. Returning empty string.");
+	            return "";
+	        }
+    	}
+
+	public static void CreateEmptyFile(string filepath)
+    	{
+		File.Create(filepath).Dispose();
+    	}
     }
 }

--- a/dotnet/DWXConnect/api/Helpers.cs
+++ b/dotnet/DWXConnect/api/Helpers.cs
@@ -103,7 +103,7 @@ namespace DWXConnect
 	        }
     	}
 
-	public static void CreateEmptyFile(string filepath)
+	private static void CreateEmptyFile(string filepath)
     	{
 		File.Create(filepath).Dispose();
     	}

--- a/dotnet/DWXConnect/api/Helpers.cs
+++ b/dotnet/DWXConnect/api/Helpers.cs
@@ -100,7 +100,7 @@ namespace DWXConnect
 	        }
 	        catch (IOException)
 	        {
-	            Console.WriteLine("api.Helpers.tryReadFile | {fileName} | IOException. Race condition. Most likely this process and the MetaTrader EA both trying to access/use the file simultaneously. Returning empty string.");
+	            Console.WriteLine($"api.Helpers.tryReadFile | {fileName} | IOException. Race condition. Most likely this process and the MetaTrader EA both trying to access/use the file simultaneously. Returning empty string.");
 	            return "";
 	        }
     	}

--- a/dotnet/DWXConnect/api/Helpers.cs
+++ b/dotnet/DWXConnect/api/Helpers.cs
@@ -81,31 +81,53 @@ namespace DWXConnect
  	*/
 	public static string tryReadFile(string path)
     	{
+		fileName = GetFileNameFromPath(path);
+		
 	        try
 	        {
 	            return File.ReadAllText(path);
 	        }
 	        catch (DirectoryNotFoundException)
 	        {
-	            Console.WriteLine("api.Helpers.tryReadFile | DirectoryNotFoundException. Returning empty string.");
+	            Console.WriteLine($"api.Helpers.tryReadFile | {fileName} | DirectoryNotFoundException. Returning empty string.");
 	            return "";
 	        }
 	        catch (FileNotFoundException)
 	        {
-	            Console.WriteLine($"api.Helpers.tryReadFile | FileNotFoundException. Creating empty file at path ({path}) & returning empty string.");
+	            Console.WriteLine($"api.Helpers.tryReadFile | {fileName} | FileNotFoundException. Creating empty file at path ({path}) & returning empty string.");
 	            CreateEmptyFile(path);
 	            return "";
 	        }
 	        catch (IOException)
 	        {
-	            Console.WriteLine("api.Helpers.tryReadFile | IOException. Race condition. Most likely this process and the MetaTrader EA both trying to access/use the file simultaneously. Returning empty string.");
+	            Console.WriteLine("api.Helpers.tryReadFile | {fileName} | IOException. Race condition. Most likely this process and the MetaTrader EA both trying to access/use the file simultaneously. Returning empty string.");
 	            return "";
 	        }
     	}
 
-	private static void CreateEmptyFile(string filepath)
+	private static void CreateEmptyFile(string filePath)
     	{
-		File.Create(filepath).Dispose();
+		File.Create(filePath).Dispose();
+    	}
+
+	private static string GetFileNameFromPath(string path)
+    	{
+	        try
+	        {
+	            return path.Split("\\").Last();
+	        }
+	        catch (Exception)
+	        {
+	            try
+	            {
+	                return path.Split("/").Last();
+	            }
+	            catch (Exception e)
+	            {
+	                Console.WriteLine(e);
+	                throw;
+	            }
+	        }
     	}
     }
 }

--- a/dotnet/DWXConnect/api/Helpers.cs
+++ b/dotnet/DWXConnect/api/Helpers.cs
@@ -81,7 +81,7 @@ namespace DWXConnect
  	*/
 	public static string tryReadFile(string path)
     	{
-		fileName = GetFileNameFromPath(path);
+		var fileName = GetFileNameFromPath(path);
 		
 	        try
 	        {


### PR DESCRIPTION
Updated the **tryReadFile** method so that it handles some exceptions and I ran into all 3 of these exceptions while building upon this code in another project and thought it might be worth contributing.

Because the **tryReadFile** method frequently gets called from a loop for checking for a file at a given path, returning an empty string after handling each exception means it will just try again at the next loop and operate smoothly without crashing the program.

- **DirectoryNotFoundException** can happen when the MetaTrader EA either isn't running or isn't initialized properly, and it returns an empty string to continue the loop that's constantly checking a filepath until it either works or possibly it can be updated to infer the status of the EA as offline which could be useful.

- **FileNotFoundException** was happening in my program even when the EA was running, and I found that by creating an empty file at location where it's expected to be fixes the problem, so it does that and returns an empty string.

- **IOException** happens when more than one process accesses the same resource at the exact same time a.k.a. a race condition. This can be handled by just returning an empty string.